### PR TITLE
Add _assertNotOnUpdateAuthInfoDispatchQueue to AuthorizationManager protocol

### DIFF
--- a/Sources/SpotifyWebAPI/API/SpotifyAPI.swift
+++ b/Sources/SpotifyWebAPI/API/SpotifyAPI.swift
@@ -333,14 +333,8 @@ extension SpotifyAPI {
     }
     
     func assertNotOnUpdateAuthInfoDispatchQueue() {
-        if let authManager = self.authorizationManager as?
-                AuthorizationCodeFlowManagerBase {
-            authManager.assertNotOnUpdateAuthInfoDispatchQueue()
-        }
-        else if let authManager = self.authorizationManager as?
-                ClientCredentialsFlowManager {
-            authManager.assertNotOnUpdateAuthInfoDispatchQueue()  
-        }
+        #if DEBUG
+        self.authorizationManager._assertNotOnUpdateAuthInfoDispatchQueue()
+        #endif
     }
-    
 }

--- a/Sources/SpotifyWebAPI/Authorization/AuthorizationCodeFlowManagerBase.swift
+++ b/Sources/SpotifyWebAPI/Authorization/AuthorizationCodeFlowManagerBase.swift
@@ -450,7 +450,7 @@ extension AuthorizationCodeFlowManagerBase {
         return expirationDate.addingTimeInterval(-tolerance) <= Date()
     }
     
-    func assertNotOnUpdateAuthInfoDispatchQueue() {
+    public func _assertNotOnUpdateAuthInfoDispatchQueue() {
         #if DEBUG
         dispatchPrecondition(
             condition: .notOnQueue(self.updateAuthInfoDispatchQueue)

--- a/Sources/SpotifyWebAPI/Authorization/ClientCredentialsFlowManager.swift
+++ b/Sources/SpotifyWebAPI/Authorization/ClientCredentialsFlowManager.swift
@@ -633,7 +633,7 @@ private extension ClientCredentialsFlowManager {
 
 extension ClientCredentialsFlowManager {
     
-    func assertNotOnUpdateAuthInfoDispatchQueue() {
+    public func _assertNotOnUpdateAuthInfoDispatchQueue() {
         #if DEBUG
         dispatchPrecondition(
             condition: .notOnQueue(self.updateAuthInfoDispatchQueue)

--- a/Sources/SpotifyWebAPI/Authorization/SpotifyAuthorizationManager.swift
+++ b/Sources/SpotifyWebAPI/Authorization/SpotifyAuthorizationManager.swift
@@ -103,4 +103,14 @@ public protocol SpotifyAuthorizationManager: Codable {
     /// Calling this method should cause `didDeauthorize` to emit a signal.
     func deauthorize() -> Void
     
+    /**
+     Used internally by the authorization managers in this library. If you
+     create your own authorization manager, do not implement this method. A
+     default implementation is provided which does nothing.
+     */
+	func _assertNotOnUpdateAuthInfoDispatchQueue()
+ }
+
+ extension SpotifyAuthorizationManager {
+	 func _assertNotOnUpdateAuthInfoDispatchQueue() { }
 }


### PR DESCRIPTION
… to avoid the type check if in callers. Since this is not a required method, it is provided with a default implementation.

Prework for https://github.com/Peter-Schorn/SpotifyAPI/pull/14/