### PR TITLE
Enable proxy endpoints to be used

### DIFF
--- a/Sources/SpotifyWebAPI/Other/Endpoints.swift
+++ b/Sources/SpotifyWebAPI/Other/Endpoints.swift
@@ -29,7 +29,7 @@ public enum Endpoints {
      "api.spotify.com"
      ```
      */
-    public static let apiBase = "api.spotify.com"
+    public static var apiBase = "api.spotify.com"
     
     /// The api version 1.
     /// ```


### PR DESCRIPTION
Change the `apiBase` to a `var` instead of a `let` in order to allow the consumer of the API to change the endpoint to a proxy endpoint.