### PR TITLE
remove SpotifyExampleContent from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     products: [
         .library(
             name: "SpotifyAPI",
-            targets: ["SpotifyWebAPI", "SpotifyExampleContent"]
+            targets: ["SpotifyWebAPI"]
         ),
         .library(
             name: "_SpotifyAPITestUtilities",


### PR DESCRIPTION
If you include SpotifyAPI using Swift Package Manager, it includes the SpotifyExampleContent in your resulting app, adding several megabytes of unused content into your app.