### PR TITLE
Update playlist images to be optional.

### DIFF
--- a/Sources/SpotifyWebAPI/Object Model/Playlist Objects/Playlist.swift
+++ b/Sources/SpotifyWebAPI/Object Model/Playlist Objects/Playlist.swift
@@ -99,7 +99,7 @@ public struct Playlist<Items: Codable & Hashable>: SpotifyURIConvertible, Hashab
      
      [1]: https://developer.spotify.com/documentation/general/guides/working-with-playlists/
      */
-    public let images: [SpotifyImage]
+    public let images: [SpotifyImage]?
     
     /// The object type. Always ``IDCategory/playlist``.
     public let type: IDCategory


### PR DESCRIPTION
The Playlist API just started returning a `null` image array (instead of an empty array as the documentation suggests and the code assumes). This change prevents the JSONDecoder from crashing when decoding such playlists.