### PR TITLE
Playlist images can be nullable

### DIFF
--- a/Sources/SpotifyWebAPI/Object Model/Playlist Objects/Playlist.swift
+++ b/Sources/SpotifyWebAPI/Object Model/Playlist Objects/Playlist.swift
@@ -99,7 +99,7 @@ public struct Playlist<Items: Codable & Hashable>: SpotifyURIConvertible, Hashab
      
      [1]: https://developer.spotify.com/documentation/general/guides/working-with-playlists/
      */
-    public let images: [SpotifyImage]
+    public let images: [SpotifyImage]?
     
     /// The object type. Always ``IDCategory/playlist``.
     public let type: IDCategory
@@ -155,7 +155,7 @@ public struct Playlist<Items: Codable & Hashable>: SpotifyURIConvertible, Hashab
         href: URL,
         id: String,
         uri: String,
-        images: [SpotifyImage]
+        images: [SpotifyImage]?
     ) {
         self.name = name
         self.items = items
@@ -187,7 +187,7 @@ extension Playlist: Codable {
 
         // MARK: Decode Images
 
-        self.images = try container.decodeSpotifyImages(forKey: .images)
+        self.images = try? container.decodeSpotifyImages(forKey: .images)
 
 
         self.name = try container.decodeIfPresent(


### PR DESCRIPTION
I've discovered that Spotify will not return an empty list of images but rather `null` when there is no image set for a playlist. This can be tested by creating a playlist and only adding local tracks, or perhaps by simply creating a playlist without any image or track (haven't tested the latter).