### PR TITLE
Made Playlist Images Optional

### DIFF
--- a/Sources/SpotifyWebAPI/Object Model/Playlist Objects/Playlist.swift
+++ b/Sources/SpotifyWebAPI/Object Model/Playlist Objects/Playlist.swift
@@ -99,7 +99,7 @@ public struct Playlist<Items: Codable & Hashable>: SpotifyURIConvertible, Hashab
      
      [1]: https://developer.spotify.com/documentation/general/guides/working-with-playlists/
      */
-    public let images: [SpotifyImage]
+    public let images: [SpotifyImage]?
     
     /// The object type. Always ``IDCategory/playlist``.
     public let type: IDCategory

--- a/Sources/SpotifyWebAPI/Object Model/Playlist Objects/Playlist.swift
+++ b/Sources/SpotifyWebAPI/Object Model/Playlist Objects/Playlist.swift
@@ -155,7 +155,7 @@ public struct Playlist<Items: Codable & Hashable>: SpotifyURIConvertible, Hashab
         href: URL,
         id: String,
         uri: String,
-        images: [SpotifyImage]
+        images: [SpotifyImage]?
     ) {
         self.name = name
         self.items = items


### PR DESCRIPTION
Spotify playlists with no tracks will have images as nil. Current Playlist model has images as non-nil & causes decoding error.

- Images are now optional in Playlist model
- Images are also optional in Playlist Initializer